### PR TITLE
Shada doesn't get disabled

### DIFF
--- a/plugin/gpg.lua
+++ b/plugin/gpg.lua
@@ -13,7 +13,7 @@ vim.api.nvim_create_autocmd({ "BufReadPre", "FileReadPre" }, {
     -- Disable undofile as it stores unencrypted data on your disk
     vim.opt_local.undofile = false
     -- Also avoid backups for this buffer
-    vim.opt_local.backup = true
+    vim.opt_local.backup = false
     vim.opt_local.writebackup = false
 
     -- Save the current 'ch' value to a buffer-local variable


### PR DESCRIPTION
I noticed everything was still being written to the shada file upon exiting the encrypted file.

Turns out vim.opt_local.shada = nil was doing nothing as shada can only be set globally for the entire Neovim instance, not per-buffer or per-window.

https://neovim.io/doc/user/options.html#'shada'

You can confirm this by entering the encrypted file and writing :set shada? which will give you your current shada setting and it won't be nil.
Or yanking / deleting something in the encrypted file, closing it and then opening a new nvim instance and checking the registers.

Setting  vim.opt.shada = "" fixes the problem.

It's also a good idea to turn off backup.
