### PR TITLE
TTY handling and agent priming

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ Vía @Frestein [Frestein/dotfiles/dot_config/nvim/lua/plugins/extras/utils/gpg.l
 
 All `*.gpg` files will be symmetrically decrypted/encrypted transparently using `gpg` tools
 
+### GPG agent TTY handling
+
+This plugin can update the GPG agent startup TTY (equivalent to
+`gpg-connect-agent updatestartuptty /bye`) to keep `pinentry-curses` attached
+to the current terminal. To enable it:
+
+```lua
+vim.g.gpg_update_tty = true
+```
+
+If you still see input issues with `pinentry-curses`, you can enable an
+optional "priming" step that runs `gpg --list-packets` on the file before
+decrypting so the passphrase is cached by the agent:
+
+```lua
+vim.g.gpg_prime_agent = true
+```
+
 ## Testing
 
 Local smoke tests (headless Neovim, temp keyring):

--- a/plugin/gpg.lua
+++ b/plugin/gpg.lua
@@ -1,5 +1,43 @@
 local gpgGroup = vim.api.nvim_create_augroup("customGpg", { clear = true })
 
+local function get_gpg_tty()
+  local gpg_tty = vim.env.GPG_TTY
+  if not gpg_tty or gpg_tty == "" then
+    local tty = vim.trim(vim.fn.system "tty")
+    if tty ~= "" and not tty:match("not a tty") then
+      gpg_tty = tty
+    end
+  end
+  return gpg_tty
+end
+
+local function update_gpg_tty()
+  if vim.g.gpg_update_tty ~= true then
+    return
+  end
+  local gpg_tty = get_gpg_tty()
+  if not gpg_tty or gpg_tty == "" then
+    return
+  end
+  vim.env.GPG_TTY = gpg_tty
+  local result = vim.system({ "gpg-connect-agent", "updatestartuptty", "/bye" }):wait()
+  if result.code ~= 0 and vim.g.gpg_update_tty_verbose then
+    vim.notify("gpg-connect-agent failed: " .. (result.stderr or ""), vim.log.levels.WARN)
+  end
+end
+
+local function prime_gpg_agent(file_path)
+  if vim.g.gpg_prime_agent ~= true then
+    return
+  end
+  if file_path == "" then
+    return
+  end
+  local escaped = vim.fn.shellescape(file_path)
+  vim.cmd("silent! !gpg --quiet --list-packets " .. escaped .. " >/dev/null 2>&1")
+  vim.cmd "redraw!"
+end
+
 vim.api.nvim_create_autocmd({ "BufReadPre", "FileReadPre" }, {
   pattern = "*.gpg",
   group = gpgGroup,
@@ -26,6 +64,8 @@ vim.api.nvim_create_autocmd({ "BufReadPost", "FileReadPost" }, {
   pattern = "*.gpg",
   group = gpgGroup,
   callback = function()
+    update_gpg_tty()
+    prime_gpg_agent(vim.fn.expand "%:p")
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
     local input = table.concat(lines, "\n")
@@ -56,6 +96,7 @@ vim.api.nvim_create_autocmd({ "BufWritePre", "FileWritePre" }, {
   pattern = "*.gpg",
   group = gpgGroup,
   callback = function()
+    update_gpg_tty()
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
     local input = table.concat(lines, "\n")

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -23,24 +23,40 @@ local function lines_equal(a, b)
   return true
 end
 
-function M.run()
-  local file = vim.fn.getenv("GPG_TEST_FILE")
-  local plaintext_file = vim.fn.getenv("GPG_TEST_PLAINTEXT_FILE")
-  local expected_file = vim.fn.getenv("GPG_TEST_EXPECTED_FILE")
-  local append_line = vim.fn.getenv("GPG_TEST_APPEND")
-
-  if file == "" or plaintext_file == "" or expected_file == "" or append_line == "" then
-    error("Missing GPG_TEST_* environment variables")
+local function get_env_or_error(name)
+  local value = vim.fn.getenv(name)
+  if value == "" then
+    error("Missing " .. name .. " environment variable")
   end
+  return value
+end
 
+local function open_file(path)
+  vim.cmd("edit " .. vim.fn.fnameescape(path))
+end
+
+local function assert_decrypted_matches(path, plaintext_file)
+  open_file(path)
+  local content_lines = normalize_lines(vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  local expected_lines = read_lines(plaintext_file)
+  if not lines_equal(content_lines, expected_lines) then
+    error("Decrypted buffer does not match plaintext fixture")
+  end
+end
+
+local function append_and_write(line)
+  vim.api.nvim_buf_set_lines(0, -1, -1, false, { line })
+  vim.cmd "write"
+end
+
+local function with_gpg_mocks()
   local original_system = vim.system
   local original_cmd = vim.cmd
-  local gpg_connect_calls = 0
-  local prime_calls = 0
+  local calls = { update_tty = 0, prime = 0 }
 
   vim.system = function(cmd, opts)
     if type(cmd) == "table" and cmd[1] == "gpg-connect-agent" then
-      gpg_connect_calls = gpg_connect_calls + 1
+      calls.update_tty = calls.update_tty + 1
       return {
         wait = function()
           return { code = 0, stdout = "", stderr = "" }
@@ -52,57 +68,70 @@ function M.run()
 
   vim.cmd = function(cmd)
     if type(cmd) == "string" and cmd:match("^silent! !gpg %-%-quiet %-%-list%-packets ") then
-      prime_calls = prime_calls + 1
+      calls.prime = calls.prime + 1
       return
     end
     return original_cmd(cmd)
   end
 
-  vim.g.gpg_update_tty = nil
-  vim.g.gpg_prime_agent = nil
-  vim.cmd("edit " .. vim.fn.fnameescape(file))
-  local content_lines = normalize_lines(vim.api.nvim_buf_get_lines(0, 0, -1, false))
-  local expected_lines = read_lines(plaintext_file)
-  if not lines_equal(content_lines, expected_lines) then
-    error("Decrypted buffer does not match plaintext fixture")
+  local function restore()
+    vim.system = original_system
+    vim.cmd = original_cmd
   end
 
-  vim.api.nvim_buf_set_lines(0, -1, -1, false, { append_line })
-  vim.cmd("write")
+  return calls, restore
+end
 
-  if gpg_connect_calls ~= 0 then
+local function assert_combo(file, update_tty, prime_agent, expect_update, expect_prime, calls)
+  local before_update = calls.update_tty
+  local before_prime = calls.prime
+  vim.g.gpg_update_tty = update_tty
+  vim.g.gpg_prime_agent = prime_agent
+  open_file(file)
+  local update_delta = calls.update_tty - before_update
+  local prime_delta = calls.prime - before_prime
+  if expect_update and update_delta == 0 then
+    error("Expected gpg_update_tty to trigger gpg-connect-agent")
+  end
+  if not expect_update and update_delta ~= 0 then
+    error("Expected gpg_update_tty to be skipped")
+  end
+  if expect_prime and prime_delta == 0 then
+    error("Expected gpg_prime_agent to trigger priming command")
+  end
+  if not expect_prime and prime_delta ~= 0 then
+    error("Expected gpg_prime_agent to be skipped")
+  end
+end
+
+function M.run()
+  local file = get_env_or_error "GPG_TEST_FILE"
+  local plaintext_file = get_env_or_error "GPG_TEST_PLAINTEXT_FILE"
+  local expected_file = get_env_or_error "GPG_TEST_EXPECTED_FILE"
+  local append_line = get_env_or_error "GPG_TEST_APPEND"
+
+  local calls, restore_mocks = with_gpg_mocks()
+
+  vim.g.gpg_update_tty = nil
+  vim.g.gpg_prime_agent = nil
+  assert_decrypted_matches(file, plaintext_file)
+  append_and_write(append_line)
+
+  if calls.update_tty ~= 0 then
     error("Expected gpg_update_tty to be disabled by default")
   end
 
-  local function assert_combo(update_tty, prime_agent, expect_update, expect_prime)
-    local before_update = gpg_connect_calls
-    local before_prime = prime_calls
-    vim.g.gpg_update_tty = update_tty
-    vim.g.gpg_prime_agent = prime_agent
-    vim.cmd("edit " .. vim.fn.fnameescape(file))
-    local update_delta = gpg_connect_calls - before_update
-    local prime_delta = prime_calls - before_prime
-    if expect_update and update_delta == 0 then
-      error("Expected gpg_update_tty to trigger gpg-connect-agent")
-    end
-    if not expect_update and update_delta ~= 0 then
-      error("Expected gpg_update_tty to be skipped")
-    end
-    if expect_prime and prime_delta == 0 then
-      error("Expected gpg_prime_agent to trigger priming command")
-    end
-    if not expect_prime and prime_delta ~= 0 then
-      error("Expected gpg_prime_agent to be skipped")
-    end
+  assert_combo(file, false, false, false, false, calls)
+  assert_combo(file, true, false, true, false, calls)
+  assert_combo(file, false, true, false, true, calls)
+  assert_combo(file, true, true, true, true, calls)
+
+  local decrypted_lines = normalize_lines(vim.fn.readfile(expected_file))
+  if #decrypted_lines == 0 then
+    error("Expected decrypted output fixture to be non-empty")
   end
 
-  assert_combo(false, false, false, false)
-  assert_combo(true, false, true, false)
-  assert_combo(false, true, false, true)
-  assert_combo(true, true, true, true)
-
-  vim.system = original_system
-  vim.cmd = original_cmd
+  restore_mocks()
 end
 
 return M

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -33,6 +33,33 @@ function M.run()
     error("Missing GPG_TEST_* environment variables")
   end
 
+  local original_system = vim.system
+  local original_cmd = vim.cmd
+  local gpg_connect_calls = 0
+  local prime_calls = 0
+
+  vim.system = function(cmd, opts)
+    if type(cmd) == "table" and cmd[1] == "gpg-connect-agent" then
+      gpg_connect_calls = gpg_connect_calls + 1
+      return {
+        wait = function()
+          return { code = 0, stdout = "", stderr = "" }
+        end,
+      }
+    end
+    return original_system(cmd, opts)
+  end
+
+  vim.cmd = function(cmd)
+    if type(cmd) == "string" and cmd:match("^silent! !gpg %-%-quiet %-%-list%-packets ") then
+      prime_calls = prime_calls + 1
+      return
+    end
+    return original_cmd(cmd)
+  end
+
+  vim.g.gpg_update_tty = nil
+  vim.g.gpg_prime_agent = nil
   vim.cmd("edit " .. vim.fn.fnameescape(file))
   local content_lines = normalize_lines(vim.api.nvim_buf_get_lines(0, 0, -1, false))
   local expected_lines = read_lines(plaintext_file)
@@ -42,6 +69,40 @@ function M.run()
 
   vim.api.nvim_buf_set_lines(0, -1, -1, false, { append_line })
   vim.cmd("write")
+
+  if gpg_connect_calls ~= 0 then
+    error("Expected gpg_update_tty to be disabled by default")
+  end
+
+  local function assert_combo(update_tty, prime_agent, expect_update, expect_prime)
+    local before_update = gpg_connect_calls
+    local before_prime = prime_calls
+    vim.g.gpg_update_tty = update_tty
+    vim.g.gpg_prime_agent = prime_agent
+    vim.cmd("edit " .. vim.fn.fnameescape(file))
+    local update_delta = gpg_connect_calls - before_update
+    local prime_delta = prime_calls - before_prime
+    if expect_update and update_delta == 0 then
+      error("Expected gpg_update_tty to trigger gpg-connect-agent")
+    end
+    if not expect_update and update_delta ~= 0 then
+      error("Expected gpg_update_tty to be skipped")
+    end
+    if expect_prime and prime_delta == 0 then
+      error("Expected gpg_prime_agent to trigger priming command")
+    end
+    if not expect_prime and prime_delta ~= 0 then
+      error("Expected gpg_prime_agent to be skipped")
+    end
+  end
+
+  assert_combo(false, false, false, false)
+  assert_combo(true, false, true, false)
+  assert_combo(false, true, false, true)
+  assert_combo(true, true, true, true)
+
+  vim.system = original_system
+  vim.cmd = original_cmd
 end
 
 return M


### PR DESCRIPTION
Note: Based off https://github.com/benoror/gpg.nvim/pull/14, need to be merged first

## Summary

- Add optional GPG agent TTY update and priming hooks to reduce pinentry-curses input issues while preserving default behavior.
- Gate the new behavior behind vim.g.gpg_update_tty and vim.g.gpg_prime_agent config flags, with gpg_update_tty now opt-in.
- Expand tests to assert all boolean combinations for the two options.

## Test Plan

- make test-bash
- make test-zsh

---

Fixes https://github.com/benoror/gpg.nvim/issues/8