### PR TITLE
fix: loopback pinentry + inputsecret for decrypt (issue #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,26 +57,43 @@ Vía @Frestein [Frestein/dotfiles/dot_config/nvim/lua/plugins/extras/utils/gpg.l
 
 ## Requirements
 
-- `gpg`
-- Optional: `pinentry-mac`
+- `gpg` (GnuPG 2.1+ recommended for loopback pinentry)
+- Optional: GUI pinentry (only needed if you disable loopback)
 
 ## Usage
 
-All `*.gpg` files will be symmetrically decrypted/encrypted transparently using `gpg` tools
+All `*.gpg` files will be decrypted/encrypted transparently using `gpg` tools
+(`--default-recipient-self` / asymmetric encrypt on write).
 
-### GPG agent TTY handling
+### Passphrase prompting (default)
 
-This plugin can update the GPG agent startup TTY (equivalent to
-`gpg-connect-agent updatestartuptty /bye`) to keep `pinentry-curses` attached
-to the current terminal. To enable it:
+By default, decrypt uses `--pinentry-mode loopback` so Neovim owns the
+passphrase prompt via `inputsecret()` when the agent does not already have the
+key cached. This avoids `pinentry-curses` TTY contention (dropped key presses)
+inside Neovim — see [issue #8](https://github.com/benoror/gpg.nvim/issues/8)
+and [docs/pinentry.md](docs/pinentry.md) for the assessment, pros/cons, and
+alternatives.
+
+Loopback is on by default. To restore the legacy external pinentry path:
+
+```lua
+vim.g.gpg_pinentry_loopback = false
+```
+
+### Legacy GPG agent TTY handling
+
+These opt-in knobs are legacy mitigations for the external pinentry path.
+Prefer the default loopback behavior above.
+
+Update the GPG agent startup TTY (equivalent to
+`gpg-connect-agent updatestartuptty /bye`):
 
 ```lua
 vim.g.gpg_update_tty = true
 ```
 
-If you still see input issues with `pinentry-curses`, you can enable an
-optional "priming" step that runs `gpg --list-packets` on the file before
-decrypting so the passphrase is cached by the agent:
+Optional "priming" step that runs `gpg --list-packets` before decrypting so
+the passphrase may be cached by the agent:
 
 ```lua
 vim.g.gpg_prime_agent = true
@@ -119,4 +136,6 @@ https://github.com/jamessan/vim-gnupg
 
 ## Further reading
 
+- [Pinentry / passphrase notes](docs/pinentry.md) (issue #8 assessment, pros/cons)
 - [Setup GPG on macOS](https://dev.to/zemse/setup-gpg-on-macos-2iib)
+- [vim-gnupg#32](https://github.com/jamessan/vim-gnupg/issues/32) (related Neovim + pinentry TTY contention)

--- a/docs/pinentry.md
+++ b/docs/pinentry.md
@@ -1,0 +1,94 @@
+# Pinentry / passphrase handling
+
+Tracking context for [issue #8](https://github.com/benoror/gpg.nvim/issues/8):
+key presses randomly dropped during `pinentry-curses` prompts under Neovim.
+
+## Assessment
+
+### Symptom
+
+When decrypting a `.gpg` buffer, `pinentry-curses` may appear on the terminal,
+but keystrokes are intermittently ignored (or split between Neovim and
+pinentry). The same class of bug exists in
+[jamessan/vim-gnupg#32](https://github.com/jamessan/vim-gnupg/issues/32).
+
+### Root cause
+
+Neovim and `pinentry-curses` contend for the same TTY:
+
+1. The plugin runs `gpg` through `vim.system()` (no dedicated PTY for pinentry).
+2. When the agent needs a passphrase, it launches pinentry against `$GPG_TTY`.
+3. Neovim continues owning terminal input, so keystrokes are raced.
+
+This is not a flaky passphrase; it is an input-routing conflict.
+
+### Why earlier mitigations were incomplete
+
+| Approach | What it does | Limitation |
+| --- | --- | --- |
+| `gpg_update_tty` (`updatestartuptty`) | Points the agent at the current TTY | Does not stop Neovim from also reading keys |
+| `gpg_prime_agent` (`gpg --list-packets`) | Tries to cache the passphrase first | Priming still needs pinentry when locked; contention remains |
+| Pre-unlock outside Neovim | Agent already has the key | Works, but is a manual workaround |
+| GUI pinentry | Avoids terminal pinentry | Not available / undesirable on SSH / headless |
+
+## Chosen fix (plugin default)
+
+Use GPG **loopback pinentry mode** and, when needed, prompt inside Neovim with
+`vim.fn.inputsecret()`, then pass the passphrase via `--passphrase-fd`.
+
+Decrypt flow:
+
+1. `gpg --batch --pinentry-mode loopback --decrypt` with ciphertext on stdin  
+   (succeeds when the agent already has the key, or the key has no passphrase).
+2. If gpg reports that it needs a passphrase, prompt with `inputsecret`.
+3. Retry with `--passphrase-fd 0` and decrypt the on-disk `.gpg` file path  
+   (stdin carries only the passphrase).
+
+Opt out (legacy pinentry UI path):
+
+```lua
+vim.g.gpg_pinentry_loopback = false
+```
+
+### Pros
+
+- Pinentry UI agnostic: no dependency on `pinentry-curses`, GTK, macOS, etc.
+- Works over SSH / headless / tmux without TTY fights.
+- Minimal surface area: still shells out to `gpg`, no PTY multiplexer.
+- Keeps ciphertext-on-stdin for the common cached-agent case.
+- Aligns with the long-term direction discussed for vim-gnupg (loopback + job control).
+
+### Cons
+
+- Changes UX for users who preferred a GUI pinentry popup (they get Neovim's secret prompt instead, unless they opt out).
+- Requires GnuPG 2.1+ loopback support (`--pinentry-mode loopback`).
+- Wrong passphrase surfaces as a decrypt error; reopen the buffer to retry.
+- Passphrase is briefly held in Lua/Neovim memory and passed on a pipe (same general class of tradeoff as any loopback/`--passphrase-fd` integration).
+
+## Alternatives not chosen
+
+### PTY-wrapped pinentry
+
+Spawn `gpg`/pinentry on a dedicated PTY (`pty = true` / `termopen`) and park
+Neovim input until it finishes.
+
+- More terminal/UI coupling, floating-term orchestration, and platform edge cases.
+- Fights the goal of keeping this plugin small and generic.
+
+### User-only configuration
+
+Setting `allow-loopback-pinentry` alone (or switching pinentry programs) does
+**not** fix the plugin path by itself: ciphertext already occupies stdin in
+`vim.system()`, so the plugin must own passphrase acquisition when loopback is
+used interactively.
+
+## Legacy optional knobs
+
+Still available when loopback is disabled, or as extra agent hygiene:
+
+```lua
+vim.g.gpg_update_tty = true
+vim.g.gpg_prime_agent = true
+```
+
+Prefer leaving loopback enabled (default) instead of relying on these.

--- a/plugin/gpg.lua
+++ b/plugin/gpg.lua
@@ -1,5 +1,9 @@
 local gpgGroup = vim.api.nvim_create_augroup("customGpg", { clear = true })
 
+local function loopback_enabled()
+  return vim.g.gpg_pinentry_loopback ~= false
+end
+
 local function get_gpg_tty()
   local gpg_tty = vim.env.GPG_TTY
   if not gpg_tty or gpg_tty == "" then
@@ -38,6 +42,88 @@ local function prime_gpg_agent(file_path)
   vim.cmd "redraw!"
 end
 
+local function normalize_gpg_stdout(stdout)
+  local output_lines = vim.split(stdout or "", "\n", { plain = true })
+  if #output_lines > 0 and output_lines[#output_lines] == "" then
+    table.remove(output_lines, #output_lines)
+  end
+  return output_lines
+end
+
+-- Detect decrypt failures that mean gpg wants a passphrase from the caller.
+local function needs_passphrase(stderr)
+  local s = stderr or ""
+  return s:find("can't get input", 1, true)
+    or s:find("No passphrase given", 1, true)
+    or s:find("Bad passphrase", 1, true)
+    or s:find("passphrase", 1, true)
+    or s:find("pinentry", 1, true)
+    or s:find("Pinentry", 1, true)
+    or s:find("Inappropriate ioctl", 1, true)
+    or s:find("public key decryption failed", 1, true)
+end
+
+local function prompt_passphrase()
+  local ok, value = pcall(vim.fn.inputsecret, "GPG passphrase: ")
+  if not ok then
+    return nil, "passphrase prompt cancelled"
+  end
+  return value, nil
+end
+
+local function gpg_decrypt_loopback(ciphertext, file_path)
+  -- First try: agent cache / unprotected keys. Never invokes pinentry UIs.
+  local result = vim.system({
+    "gpg",
+    "--batch",
+    "--yes",
+    "--pinentry-mode",
+    "loopback",
+    "--decrypt",
+  }, { stdin = ciphertext }):wait()
+
+  if result.code == 0 then
+    return result
+  end
+
+  if not needs_passphrase(result.stderr) then
+    return result
+  end
+
+  if not file_path or file_path == "" then
+    result.stderr = (result.stderr or "")
+      .. "\ngpg.nvim: passphrase required but buffer has no file path"
+    return result
+  end
+
+  local passphrase, prompt_err = prompt_passphrase()
+  if prompt_err then
+    result.code = 1
+    result.stderr = prompt_err
+    return result
+  end
+
+  -- Passphrase on stdin (fd 0); ciphertext from the on-disk encrypted file.
+  result = vim.system({
+    "gpg",
+    "--batch",
+    "--yes",
+    "--pinentry-mode",
+    "loopback",
+    "--passphrase-fd",
+    "0",
+    "--decrypt",
+    "--",
+    file_path,
+  }, { stdin = passphrase .. "\n" }):wait()
+
+  return result
+end
+
+local function gpg_decrypt_legacy(ciphertext)
+  return vim.system({ "gpg", "--decrypt" }, { stdin = ciphertext }):wait()
+end
+
 vim.api.nvim_create_autocmd({ "BufReadPre", "FileReadPre" }, {
   pattern = "*.gpg",
   group = gpgGroup,
@@ -65,19 +151,24 @@ vim.api.nvim_create_autocmd({ "BufReadPost", "FileReadPost" }, {
   group = gpgGroup,
   callback = function()
     update_gpg_tty()
-    prime_gpg_agent(vim.fn.expand "%:p")
+    local file_path = vim.fn.expand "%:p"
+    prime_gpg_agent(file_path)
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
     local input = table.concat(lines, "\n")
-    local result = vim.system({ "gpg", "--decrypt" }, { stdin = input }):wait()
+
+    local result
+    if loopback_enabled() then
+      result = gpg_decrypt_loopback(input, file_path)
+    else
+      result = gpg_decrypt_legacy(input)
+    end
+
     if result.code ~= 0 then
       vim.notify("gpg decrypt failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
       return
     end
-    local output_lines = vim.split(result.stdout, "\n", { plain = true })
-    if #output_lines > 0 and output_lines[#output_lines] == "" then
-      table.remove(output_lines, #output_lines)
-    end
+    local output_lines = normalize_gpg_stdout(result.stdout)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, output_lines)
     vim.api.nvim_buf_set_option(buf, "modified", false)
 
@@ -105,10 +196,7 @@ vim.api.nvim_create_autocmd({ "BufWritePre", "FileWritePre" }, {
       vim.notify("gpg encrypt failed: " .. (result.stderr or ""), vim.log.levels.ERROR)
       return
     end
-    local output_lines = vim.split(result.stdout, "\n", { plain = true })
-    if #output_lines > 0 and output_lines[#output_lines] == "" then
-      table.remove(output_lines, #output_lines)
-    end
+    local output_lines = normalize_gpg_stdout(result.stdout)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, output_lines)
     vim.api.nvim_buf_set_option(buf, "modified", false)
   end,

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -24,6 +24,8 @@ mkdir -p "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
 export GNUPGHOME="$TMP_DIR/gnupg"
 mkdir -p "$GNUPGHOME"
 chmod 700 "$GNUPGHOME"
+# Permit loopback pinentry used by the plugin's default decrypt path.
+printf 'allow-loopback-pinentry\n' > "$GNUPGHOME/gpg-agent.conf"
 
 PLAINTEXT_FILE="$TMP_DIR/plain.txt"
 EXPECTED_FILE="$TMP_DIR/expected.txt"
@@ -50,7 +52,9 @@ export GPG_TEST_PLAINTEXT_FILE="$PLAINTEXT_FILE"
 export GPG_TEST_EXPECTED_FILE="$EXPECTED_FILE"
 export GPG_TEST_APPEND="$GPG_APPEND_LINE"
 
-nvim --headless -u "$INIT_FILE" +"lua require('tests.test').run()" +qa
+nvim --headless -u "$INIT_FILE" \
+  -c "lua local ok, err = pcall(require('tests.test').run); if not ok then io.stderr:write(tostring(err) .. '\n'); vim.cmd('cquit 1') end" \
+  -c qa
 
 gpg --batch --decrypt "$GPG_FILE" > "$TMP_DIR/decrypted.txt"
 if ! diff -u "$EXPECTED_FILE" "$TMP_DIR/decrypted.txt" >/dev/null; then

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -49,10 +49,26 @@ local function append_and_write(line)
   vim.cmd "write"
 end
 
+local function cmd_has(cmd, value)
+  for _, part in ipairs(cmd) do
+    if part == value then
+      return true
+    end
+  end
+  return false
+end
+
 local function with_gpg_mocks()
   local original_system = vim.system
   local original_cmd = vim.cmd
-  local calls = { update_tty = 0, prime = 0 }
+  local calls = {
+    update_tty = 0,
+    prime = 0,
+    decrypt = 0,
+    decrypt_loopback = 0,
+    decrypt_legacy = 0,
+    decrypt_passphrase_fd = 0,
+  }
 
   vim.system = function(cmd, opts)
     if type(cmd) == "table" and cmd[1] == "gpg-connect-agent" then
@@ -62,6 +78,17 @@ local function with_gpg_mocks()
           return { code = 0, stdout = "", stderr = "" }
         end,
       }
+    end
+    if type(cmd) == "table" and cmd[1] == "gpg" and cmd_has(cmd, "--decrypt") then
+      calls.decrypt = calls.decrypt + 1
+      if cmd_has(cmd, "--pinentry-mode") and cmd_has(cmd, "loopback") then
+        calls.decrypt_loopback = calls.decrypt_loopback + 1
+      else
+        calls.decrypt_legacy = calls.decrypt_legacy + 1
+      end
+      if cmd_has(cmd, "--passphrase-fd") then
+        calls.decrypt_passphrase_fd = calls.decrypt_passphrase_fd + 1
+      end
     end
     return original_system(cmd, opts)
   end
@@ -85,6 +112,10 @@ end
 local function assert_combo(file, update_tty, prime_agent, expect_update, expect_prime, calls)
   local before_update = calls.update_tty
   local before_prime = calls.prime
+  -- Headless runs have no TTY; set a dummy so update_gpg_tty reaches gpg-connect-agent.
+  if not vim.env.GPG_TTY or vim.env.GPG_TTY == "" then
+    vim.env.GPG_TTY = "/dev/tty"
+  end
   vim.g.gpg_update_tty = update_tty
   vim.g.gpg_prime_agent = prime_agent
   open_file(file)
@@ -104,6 +135,106 @@ local function assert_combo(file, update_tty, prime_agent, expect_update, expect
   end
 end
 
+local function assert_loopback_default(file, plaintext_file, calls)
+  vim.g.gpg_pinentry_loopback = nil
+  local before = calls.decrypt_loopback
+  assert_decrypted_matches(file, plaintext_file)
+  if calls.decrypt_loopback <= before then
+    error("Expected default decrypt to use --pinentry-mode loopback")
+  end
+  if calls.decrypt_passphrase_fd ~= 0 then
+    error("Did not expect passphrase-fd for unprotected/cached key")
+  end
+end
+
+local function assert_legacy_opt_out(file, plaintext_file, calls)
+  vim.g.gpg_pinentry_loopback = false
+  local before_legacy = calls.decrypt_legacy
+  local before_loopback = calls.decrypt_loopback
+  assert_decrypted_matches(file, plaintext_file)
+  if calls.decrypt_legacy <= before_legacy then
+    error("Expected gpg_pinentry_loopback=false to use legacy decrypt")
+  end
+  if calls.decrypt_loopback ~= before_loopback then
+    error("Did not expect loopback decrypt when opted out")
+  end
+  vim.g.gpg_pinentry_loopback = nil
+end
+
+local function assert_passphrase_retry(file, plaintext_file)
+  local original_system = vim.system
+  local original_inputsecret = vim.fn.inputsecret
+  local attempts = 0
+  local prompted = false
+
+  vim.g.gpg_pinentry_loopback = true
+  vim.fn.inputsecret = function()
+    prompted = true
+    return "test-passphrase"
+  end
+
+  vim.system = function(cmd, opts)
+    if type(cmd) == "table" and cmd[1] == "gpg" and cmd_has(cmd, "--decrypt") then
+      attempts = attempts + 1
+      if attempts == 1 then
+        if not (cmd_has(cmd, "--pinentry-mode") and cmd_has(cmd, "loopback")) then
+          error("First decrypt attempt should use loopback")
+        end
+        if cmd_has(cmd, "--passphrase-fd") then
+          error("First decrypt attempt should not use passphrase-fd")
+        end
+        return {
+          wait = function()
+            return {
+              code = 2,
+              stdout = "",
+              stderr = "gpg: Sorry, we are in batchmode - can't get input",
+            }
+          end,
+        }
+      end
+
+      if not cmd_has(cmd, "--passphrase-fd") then
+        error("Retry should use --passphrase-fd")
+      end
+      if opts == nil or type(opts.stdin) ~= "string" or not opts.stdin:find("test-passphrase", 1, true) then
+        error("Retry should pass passphrase on stdin")
+      end
+      if not cmd_has(cmd, file) then
+        error("Retry should decrypt the on-disk file path")
+      end
+
+      -- Fall through to real decrypt with empty passphrase key after consuming fd.
+      return original_system({
+        "gpg",
+        "--batch",
+        "--yes",
+        "--pinentry-mode",
+        "loopback",
+        "--decrypt",
+        "--",
+        file,
+      }, {})
+    end
+    return original_system(cmd, opts)
+  end
+
+  local ok, err = pcall(assert_decrypted_matches, file, plaintext_file)
+  vim.system = original_system
+  vim.fn.inputsecret = original_inputsecret
+  vim.g.gpg_pinentry_loopback = nil
+
+  if not ok then
+    error(err)
+  end
+  if not prompted then
+    error("Expected inputsecret prompt when loopback decrypt needs a passphrase")
+  end
+  if attempts ~= 2 then
+    error("Expected exactly one retry after passphrase prompt, got " .. tostring(attempts))
+  end
+end
+
 function M.run()
   local file = get_env_or_error "GPG_TEST_FILE"
   local plaintext_file = get_env_or_error "GPG_TEST_PLAINTEXT_FILE"
@@ -114,24 +245,36 @@ function M.run()
 
   vim.g.gpg_update_tty = nil
   vim.g.gpg_prime_agent = nil
-  assert_decrypted_matches(file, plaintext_file)
-  append_and_write(append_line)
+  vim.g.gpg_pinentry_loopback = nil
+  assert_loopback_default(file, plaintext_file, calls)
+  assert_legacy_opt_out(file, plaintext_file, calls)
 
   if calls.update_tty ~= 0 then
     error("Expected gpg_update_tty to be disabled by default")
   end
+
+  -- Content checks that need the unmodified fixture must run before write.
+  restore_mocks()
+  assert_passphrase_retry(file, plaintext_file)
+
+  calls, restore_mocks = with_gpg_mocks()
+  vim.g.gpg_update_tty = nil
+  vim.g.gpg_prime_agent = nil
+  vim.g.gpg_pinentry_loopback = nil
+  assert_decrypted_matches(file, plaintext_file)
+  append_and_write(append_line)
 
   assert_combo(file, false, false, false, false, calls)
   assert_combo(file, true, false, true, false, calls)
   assert_combo(file, false, true, false, true, calls)
   assert_combo(file, true, true, true, true, calls)
 
+  restore_mocks()
+
   local decrypted_lines = normalize_lines(vim.fn.readfile(expected_file))
   if #decrypted_lines == 0 then
     error("Expected decrypted output fixture to be non-empty")
   end
-
-  restore_mocks()
 end
 
 return M


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `pinentry-curses` dropped-keypress issue ([#8](https://github.com/benoror/gpg.nvim/issues/8)) with a minimal, pinentry-agnostic approach:

1. Decrypt with `gpg --batch --pinentry-mode loopback` first (agent cache / unprotected keys).
2. If gpg reports a passphrase is required, prompt via `vim.fn.inputsecret()`.
3. Retry with `--passphrase-fd 0` against the on-disk `.gpg` path.

Legacy external pinentry remains available via `vim.g.gpg_pinentry_loopback = false`. The older `gpg_update_tty` / `gpg_prime_agent` knobs stay as optional mitigations for that path.

## Documentation

- README: documents the default loopback behavior and legacy opt-out.
- [`docs/pinentry.md`](docs/pinentry.md): assessment, root cause, why prior mitigations were incomplete, pros/cons, and alternatives (PTY / user-only config) not chosen.

## Test plan

- [x] `make test-bash`
- [ ] `make test-zsh` / `make test-nu` (CI)
- [ ] Manual: open a passphrase-protected `.gpg` in a terminal Neovim session and confirm Neovim’s secret prompt works without dropped keys
- [ ] Manual: with agent already unlocked, confirm open works with no prompt
- [ ] Manual: `vim.g.gpg_pinentry_loopback = false` still uses legacy pinentry

Fixes #8

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdd81-db8e-702d-bfcc-9c7a331f99ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdd81-db8e-702d-bfcc-9c7a331f99ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

