### PR TITLE
docs: document selection encrypt/decrypt via Neovim filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,41 @@ Vía @Frestein [Frestein/dotfiles/dot_config/nvim/lua/plugins/extras/utils/gpg.l
 All `*.gpg` files will be decrypted/encrypted transparently using `gpg` tools
 (`--default-recipient-self` / asymmetric encrypt on write).
 
+### Encrypting / decrypting a visual selection
+
+This plugin intentionally stays focused on transparent whole-file editing for
+`*.gpg` (and similar) buffers. Inline encrypt/decrypt of a visual selection —
+including picking recipients from your keyring — is left to Neovim's built-in
+external filter (`:!`) and `gpg`, so the plugin remains small and agnostic.
+
+Select text in visual mode, then:
+
+```vim
+" Encrypt to yourself (ASCII-armored)
+:'<,'>!gpg -ae --default-recipient-self
+
+" Encrypt to a specific recipient
+:'<,'>!gpg -ae -r alice@example.com
+
+" Decrypt an armored PGP block
+:'<,'>!gpg -qd
+```
+
+Optional keymaps:
+
+```lua
+vim.keymap.set("v", "<leader>ge", ":!gpg -ae --default-recipient-self<CR>", {
+  desc = "GPG encrypt selection",
+})
+vim.keymap.set("v", "<leader>gd", ":!gpg -qd<CR>", {
+  desc = "GPG decrypt selection",
+})
+```
+
+For a recipient picker, list keys with `gpg --list-keys`, choose with
+`vim.ui.select` / Telescope / fzf-lua, then run the same filter with one or more
+`-r` flags. That UI is config-local and out of scope for this plugin.
+
 ### Passphrase prompting (default)
 
 By default, decrypt uses `--pinentry-mode loopback` so Neovim owns the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Documents that inline visual-selection encrypt/decrypt (with recipient picking) is intentionally **out of scope** for this plugin.
- Adds README hints for the built-in Neovim `:!` + `gpg` filter workflow, optional keymaps, and how to layer a local recipient picker.
- Keeps the plugin focused on transparent whole-file `*.gpg` editing.
- Rebased onto latest `main` (post loopback pinentry docs).

Related: https://github.com/benoror/gpg.nvim/issues/16 (closed as not planned).

## Test plan

- [x] README section renders correctly on GitHub
- [x] Filter examples match expected `gpg` CLI usage (`-ae`, `-r`, `-qd`)
- [x] No merge conflict with `main` pinentry docs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdd8d-41cf-7c21-a82a-571097680c87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdd8d-41cf-7c21-a82a-571097680c87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

